### PR TITLE
Add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+# This file was yoinked from https://github.com/github/gitignore/blob/main/Nextjs.gitignore
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env*.local
+.env
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts


### PR DESCRIPTION
A project should have a `.gitignore`, which indicates to git files that should not be saved to the repository. More about this standard practice can be read here: https://docs.github.com/en/get-started/git-basics/ignoring-files

Since the project is Next.js, this one was grabbed from: https://github.com/github/gitignore/blob/main/Nextjs.gitignore